### PR TITLE
fix: redirect low-level logging functions to STDERR to prevent helper function corruption

### DIFF
--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -32,7 +32,7 @@ log() {
 
   local ts
   ts=$(date '+%H:%M:%S')
-  echo -e "${color}[${label}]${NC} ${msg}"
+  echo -e "${color}[${label}]${NC} ${msg}" >&2
 
   if [ -n "$LOG_FILE" ]; then
     echo "[${ts}] [${label}] ${msg}" >> "$LOG_FILE" 2>/dev/null || true
@@ -40,7 +40,7 @@ log() {
 }
 
 error_exit() {
-  log "ERROR" "$1" >&2
+  log "ERROR" "$1"
   exit 1
 }
 

--- a/unleash-standalone.sh
+++ b/unleash-standalone.sh
@@ -35,7 +35,7 @@ log() {
 
   local ts
   ts=$(date '+%H:%M:%S')
-  echo -e "${color}[${label}]${NC} ${msg}"
+  echo -e "${color}[${label}]${NC} ${msg}" >&2
 
   if [ -n "$LOG_FILE" ]; then
     echo "[${ts}] [${label}] ${msg}" >> "$LOG_FILE" 2>/dev/null || true
@@ -43,7 +43,7 @@ log() {
 }
 
 error_exit() {
-  log "ERROR" "$1" >&2
+  log "ERROR" "$1"
   exit 1
 }
 


### PR DESCRIPTION
## Summary

### Problem
The `log` function in both `unleash-standalone.sh` and `lib/colors.sh` natively utilized the standard `echo` command without stream redirection, sending diagnostic logs straight to the standard output. 

However, the script simultaneously relies on modular helper functions that utilize `echo` to return actual data payloads back to the parent functions. Because these helper functions also trigger high-level log wrappers (`warn`, `success`, etc.) during runtime, the TUI-based log messages were accidentally prepended directly into the outputs of the helper functions instead of only being displayed within the user's terminal.

#### Consequences
Without boundary checks or explicit data validation, parent functions attempted to parse these composite strings as system variables. This caused unpredictable and highly erratic script execution, most notably causing the script to inadvertently create phantom directory chains recursively matching log text string names.

### Solution
Modified the core `log` function block to shift terminal UI components explicitly onto the standard error stream (`>&2`):
* `echo -e "${color}[${label}]${NC} ${msg}" >&2`

This guarantees that log markers are visible to user terminals without mixing into the payload buffers designed for capturing helper function output.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] CI / infrastructure

## Checklist

- [x] `make lint` passes
- [x] `make test` passes
- [x] Tested on a real Mac (Intel or Apple Silicon)