### PR TITLE
docs: update recovery curl command to use standalone script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ No internet needed. No SIP to disable. No typing long URLs.
 If you do have internet in Recovery:
 
 ```bash
-curl -L https://raw.githubusercontent.com/mateussiqueira/unleash/main/unleash -o /tmp/unleash
+curl -L https://raw.githubusercontent.com/mateussiqueira/unleash/main/unleash-standalone.sh -o /tmp/unleash
 chmod +x /tmp/unleash && /tmp/unleash bypass
 ```
 


### PR DESCRIPTION
## Summary

### Problem
The README previously instructed users who have internet in Recovery mode to download and execute the modular `unleash` script directly via `curl`. 

Because the modular script relies on sourcing external helper files from a local `lib/` directory (such as `lib/colors.sh`), running it as a single, isolated file download throws fatal missing-library errors. 

### Solution
Updated the `curl` documentation snippet to reference `unleash-standalone.sh` instead of the modular wrapper. The standalone script includes all necessary library blocks compiled into a single file, allowing it to download and execute flawlessly without requiring a full repository clone.

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] CI / infrastructure

## Checklist

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Tested on a real Mac (Intel or Apple Silicon)

## Related

Fixes issue #14